### PR TITLE
fix: Use version range to specify gRPC dependency

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,8 +3,3 @@ update_configs:
   - package_manager: "java:gradle"
     directory: "/"
     update_schedule: "weekly"
-    ignored_updates:
-      - match:
-          # See: https://github.com/relaycorp/relaynet-courier-android/issues/231
-          dependency_name: "io.grpc:grpc-*"
-          version_requirement: "1.x"

--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,8 @@ repositories {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
-  // Use a version range to make it easy to upgrade the CogRPC library in the application code
   api 'tech.relaycorp:cogrpc:[1.1.6,2.0.0)'
-
-  // Pin an old grpc-java version: https://github.com/relaycorp/relaynet-courier-android/issues/231
-  api "io.grpc:grpc-okhttp:1.34.1"
+  api "io.grpc:grpc-okhttp:[1.32.2,2.0.0)"
 
   // Testing
   testImplementation "org.junit.jupiter:junit-jupiter:5.7.0"


### PR DESCRIPTION
To start fix for https://github.com/relaycorp/relaynet-courier-android/issues/231